### PR TITLE
fix Encoding::UndefinedConversionError exeption

### DIFF
--- a/lib/kakasi/ffi.rb
+++ b/lib/kakasi/ffi.rb
@@ -44,7 +44,7 @@ module Kakasi
 
         encoding = string.encoding
         result = ''.force_encoding(INTERNAL_ENCODING)
-        string.encode(INTERNAL_ENCODING).split(/(\0+)/).each { |str, nul|
+        string.encode(INTERNAL_ENCODING, invalid: :replace, undef: :replace, replace: '_').split(/(\0+)/).each { |str, nul|
           buf = kakasi_do(str)
           result << buf.read_string.force_encoding(INTERNAL_ENCODING)
           kakasi_free(buf)

--- a/lib/kakasi/fiddle.rb
+++ b/lib/kakasi/fiddle.rb
@@ -51,7 +51,7 @@ module Kakasi
 
         encoding = string.encoding
         result = ''.force_encoding(INTERNAL_ENCODING)
-        string.encode(INTERNAL_ENCODING).split(/(\0+)/).each { |str, nul|
+        string.encode(INTERNAL_ENCODING, invalid: :replace, undef: :replace, replace: '_').split(/(\0+)/).each { |str, nul|
           buf = kakasi_do(str)
           result << buf.to_s.force_encoding(INTERNAL_ENCODING)
           kakasi_free(buf)


### PR DESCRIPTION
fix Encoding::UndefinedConversionError exeption by replacing
unknown characters with '_' when encoding to CP932/Windows-31J

If we pass through CP932 encoding then we must decide how
to handle the eventual missing characters.